### PR TITLE
Namespace everything under GraphQL::Parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ Or install it yourself as:
 Parse your graphql string to get an AST:
 ```ruby
 require 'graphql/parser'
-ast = GraphQL::Parser.parse('{ some_graphql_string }') # returns GraphQL::AST
+ast = GraphQL::Parser.parse('{ some_graphql_string }') # returns GraphQL::Parser::AST
 ```
 
-This will raise `GraphQL::ParseError` on malformed input.
+This will raise `GraphQL::Parser::Error` on malformed input.
 
 Implement a visitor:
 ```ruby
-class MyVisitor < GraphQL::Visitor
+class MyVisitor < GraphQL::Parser::Visitor
   def visit_document(node)
     # do something interesting in pre-order
   end
@@ -52,7 +52,7 @@ v = MyVisitor.new
 v.accept(ast)
 ```
 
-You can return `GraphQL::SKIP_CHILDREN` from a visitor to skip visiting that
+You can return `GraphQL::Parser::SKIP_CHILDREN` from a visitor to skip visiting that
 node's children.
 
 ## Contributing

--- a/ext/graphql_parser/graphql_ruby.c
+++ b/ext/graphql_parser/graphql_ruby.c
@@ -722,49 +722,47 @@ static VALUE accept(VALUE self, VALUE ast) {
 }
 
 void init_graphql(void) {
-  VALUE module, parser, visitor, node_class;
+  VALUE parent_module = rb_define_module("GraphQL");
 
-  module = rb_define_module("GraphQL");
-
-  parser = rb_define_module_under(module, "Parser");
+  VALUE parser = rb_define_module_under(parent_module, "Parser");
   rb_define_module_function(parser, "parse", parse, 1);
 
-  visitor = rb_define_class_under(module, "Visitor", rb_cObject);
+  VALUE visitor = rb_define_class_under(parser, "Visitor", rb_cObject);
   rb_define_method(visitor, "accept", accept, 1);
 
-  parse_error = rb_define_class_under(module, "ParseError", rb_eArgError);
+  parse_error = rb_define_class_under(parser, "Error", rb_eArgError);
 
-  ast_class = rb_define_class_under(module, "AST", rb_cObject);
+  ast_class = rb_define_class_under(parser, "AST", rb_cObject);
 
-  node_class = rb_define_class_under(module, "Node", rb_cObject);
+  VALUE node_class = rb_define_class_under(parser, "Node", rb_cObject);
 
   skip_children = rb_class_new_instance(0, NULL, rb_cObject);
-  rb_define_const(module, "SKIP_CHILDREN", skip_children);
+  rb_define_const(parser, "SKIP_CHILDREN", skip_children);
 
 
-  document_class = rb_define_class_under(module, "Document", node_class);
-  operation_definition_class = rb_define_class_under(module, "OperationDefinition", node_class);
-  variable_definition_class = rb_define_class_under(module, "VariableDefinition", node_class);
-  selection_set_class = rb_define_class_under(module, "SelectionSet", node_class);
-  field_class = rb_define_class_under(module, "Field", node_class);
-  argument_class = rb_define_class_under(module, "Argument", node_class);
-  fragment_spread_class = rb_define_class_under(module, "FragmentSpread", node_class);
-  inline_fragment_class = rb_define_class_under(module, "InlineFragment", node_class);
-  fragment_definition_class = rb_define_class_under(module, "FragmentDefinition", node_class);
-  variable_class = rb_define_class_under(module, "Variable", node_class);
-  int_value_class = rb_define_class_under(module, "IntValue", node_class);
-  float_value_class = rb_define_class_under(module, "FloatValue", node_class);
-  string_value_class = rb_define_class_under(module, "StringValue", node_class);
-  boolean_value_class = rb_define_class_under(module, "BooleanValue", node_class);
-  enum_value_class = rb_define_class_under(module, "EnumValue", node_class);
-  array_value_class = rb_define_class_under(module, "ArrayValue", node_class);
-  object_value_class = rb_define_class_under(module, "ObjectValue", node_class);
-  object_field_class = rb_define_class_under(module, "ObjectField", node_class);
-  directive_class = rb_define_class_under(module, "Directive", node_class);
-  named_type_class = rb_define_class_under(module, "NamedType", node_class);
-  list_type_class = rb_define_class_under(module, "ListType", node_class);
-  non_null_type_class = rb_define_class_under(module, "NonNullType", node_class);
-  name_class = rb_define_class_under(module, "Name", node_class);
+  document_class = rb_define_class_under(parser, "Document", node_class);
+  operation_definition_class = rb_define_class_under(parser, "OperationDefinition", node_class);
+  variable_definition_class = rb_define_class_under(parser, "VariableDefinition", node_class);
+  selection_set_class = rb_define_class_under(parser, "SelectionSet", node_class);
+  field_class = rb_define_class_under(parser, "Field", node_class);
+  argument_class = rb_define_class_under(parser, "Argument", node_class);
+  fragment_spread_class = rb_define_class_under(parser, "FragmentSpread", node_class);
+  inline_fragment_class = rb_define_class_under(parser, "InlineFragment", node_class);
+  fragment_definition_class = rb_define_class_under(parser, "FragmentDefinition", node_class);
+  variable_class = rb_define_class_under(parser, "Variable", node_class);
+  int_value_class = rb_define_class_under(parser, "IntValue", node_class);
+  float_value_class = rb_define_class_under(parser, "FloatValue", node_class);
+  string_value_class = rb_define_class_under(parser, "StringValue", node_class);
+  boolean_value_class = rb_define_class_under(parser, "BooleanValue", node_class);
+  enum_value_class = rb_define_class_under(parser, "EnumValue", node_class);
+  array_value_class = rb_define_class_under(parser, "ArrayValue", node_class);
+  object_value_class = rb_define_class_under(parser, "ObjectValue", node_class);
+  object_field_class = rb_define_class_under(parser, "ObjectField", node_class);
+  directive_class = rb_define_class_under(parser, "Directive", node_class);
+  named_type_class = rb_define_class_under(parser, "NamedType", node_class);
+  list_type_class = rb_define_class_under(parser, "ListType", node_class);
+  non_null_type_class = rb_define_class_under(parser, "NonNullType", node_class);
+  name_class = rb_define_class_under(parser, "Name", node_class);
 
   rb_define_method(document_class, "definitions_size", document_get_definitions_size, 0);
   rb_define_method(operation_definition_class, "operation", operation_definition_get_operation, 0);

--- a/lib/graphql/parser/visitor.rb
+++ b/lib/graphql/parser/visitor.rb
@@ -1,6 +1,3 @@
-require 'graphql/parser/version'
-require 'graphql_parser'
-
 module GraphQL
   module Parser
     class Visitor

--- a/lib/graphql/visitor.rb
+++ b/lib/graphql/visitor.rb
@@ -1,6 +1,0 @@
-require 'graphql_parser'
-
-module GraphQL
-  class Visitor
-  end
-end

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -26,12 +26,12 @@ class ParserTest < Minitest::Test
   private
 
   def expect_parse_error(input)
-    assert_raises(GraphQL::ParseError) do
+    assert_raises(GraphQL::Parser::Error) do
       GraphQL::Parser.parse(input)
     end
   end
 
   def expect_parse_success(input)
-    assert_equal GraphQL::AST, GraphQL::Parser.parse(input).class
+    assert_equal GraphQL::Parser::AST, GraphQL::Parser.parse(input).class
   end
 end

--- a/test/visitor_test.rb
+++ b/test/visitor_test.rb
@@ -1,7 +1,7 @@
 require_relative 'test_helper'
 
 class VisitorTest < Minitest::Test
-  class NameVisitor < GraphQL::Visitor
+  class NameVisitor < GraphQL::Parser::Visitor
     attr_accessor :nodes
 
     def initialize
@@ -30,10 +30,10 @@ class VisitorTest < Minitest::Test
     ], v.nodes
   end
 
-  class SkipChildrenVisitor < GraphQL::Visitor
+  class SkipChildrenVisitor < GraphQL::Parser::Visitor
     def visit_document(node)
       @nodes << :visit_document
-      GraphQL::SKIP_CHILDREN
+      SKIP_CHILDREN
     end
   end
 
@@ -46,7 +46,7 @@ class VisitorTest < Minitest::Test
     ], v.nodes
   end
 
-  class NodeVisitor < GraphQL::Visitor
+  class NodeVisitor < GraphQL::Parser::Visitor
     attr_accessor :nodes
 
     def initialize
@@ -62,25 +62,25 @@ class VisitorTest < Minitest::Test
     v = NodeVisitor.new
     v.accept(GraphQL::Parser.parse('{ field }'))
 
-    assert_equal GraphQL::Document, v.nodes[0].class
+    assert_equal GraphQL::Parser::Document, v.nodes[0].class
     assert_equal 1, v.nodes[0].definitions_size
 
-    assert_equal GraphQL::OperationDefinition, v.nodes[1].class
+    assert_equal GraphQL::Parser::OperationDefinition, v.nodes[1].class
     assert_equal 'query', v.nodes[1].operation
     assert_nil v.nodes[1].name
-    assert_equal GraphQL::SelectionSet, v.nodes[1].selection_set.class
+    assert_equal GraphQL::Parser::SelectionSet, v.nodes[1].selection_set.class
     assert_equal 0, v.nodes[1].variable_definitions_size
     assert_equal 0, v.nodes[1].directives_size
 
-    assert_equal GraphQL::SelectionSet, v.nodes[2].class
+    assert_equal GraphQL::Parser::SelectionSet, v.nodes[2].class
     assert_equal 1, v.nodes[2].selections_size
 
-    assert_equal GraphQL::Field, v.nodes[3].class
+    assert_equal GraphQL::Parser::Field, v.nodes[3].class
     assert_nil v.nodes[3].alias
-    assert_equal GraphQL::Name, v.nodes[3].name.class
+    assert_equal GraphQL::Parser::Name, v.nodes[3].name.class
     assert_equal 'field', v.nodes[3].name.value
 
-    assert_equal GraphQL::Name, v.nodes[4].class
+    assert_equal GraphQL::Parser::Name, v.nodes[4].class
     assert_equal 'field', v.nodes[4].value
   end
 end


### PR DESCRIPTION
@eapache for review

Fixes #5

Having graphql-parser as the gem name implies all the code should live in GraphQL::Parser.  In this case it is very important since there is already a graphql gem that uses the GraphQL namespace.