### PR TITLE
Add test for parsing subscriptions which currently errors

### DIFF
--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -6,7 +6,9 @@ class ParserTest < Minitest::Test
 
   def test_that_parsing_returns_an_ast
     expect_parse_success('{ field }')
+    expect_parse_success('query { field }')
     expect_parse_success('{ field(complex: { a: { b: [ $var ] } }) }')
+    expect_parse_success('subscription subscriptionName{ field }')
   end
 
   def test_parse_error


### PR DESCRIPTION
libgraphqlparser currently seems to handle subscriptions:
"type OperationKind = 'query' | 'mutation' | 'subscription';'''"

However, graphql-parser complains with:
"GraphQL::Parser::Error: 1.1-12: syntax error, unexpected IDENTIFIER, expecting fragment or mutation or query or {"